### PR TITLE
allow only single word for verb and entity (no spaces)

### DIFF
--- a/lib/advanced_adapter/libs/channel.coffee
+++ b/lib/advanced_adapter/libs/channel.coffee
@@ -32,6 +32,6 @@ class Channel
     @nice_name = nice_name
     @topic = topic
     # convert time to timestamp
-    @created = new Date(created).getTime() || '';
+    @created = new Date(created).getTime() || ''
 
 module.exports = Channel

--- a/src/0_bootstrap.coffee
+++ b/src/0_bootstrap.coffee
@@ -91,16 +91,17 @@ module.exports = (robot) ->
     if info.action
       info.verb = info.action
       delete info.action
-    if !info.verb
-      throw new Error("Cannot register function for #{integration_name}, "+
-        "no verb passed")
     info.product = info.product || integration_name
+    if !info.verb
+      throw new Error("Cannot register listener for #{info.product}, "+
+        "no verb passed")
+    if info.verb.includes(" ") || (info.entity && info.entity.includes(" "))
+      throw new Error("Cannot register listener for #{info.product}, "+
+        "verb/entity must be a single word")
     extra = if info.extra then " "+info.extra else "[ ]?(.*)?"
     if !info.type || (info.type != 'hear')
       info.type = 'respond'
-    re_string = info.product
-    if info.verb
-      re_string += " #{info.verb}"
+    re_string = "#{info.product} #{info.verb}"
     if info.entity
       re_string += " #{info.entity}"
     re_string+= "#{extra}"

--- a/src/0_bootstrap.coffee
+++ b/src/0_bootstrap.coffee
@@ -120,7 +120,8 @@ module.exports = (robot) ->
   # callback: function to run
   #
   # will register function with the following regex:
-  # robot[info.type] /#{info.product} #{info.verb} #{info.entity} #{info.extra}/i
+  # robot[info.type]
+  #  /#{info.product} #{info.verb} #{info.entity} #{info.extra}/i
   robot.e.create = (info, callback) ->
     re = build_enterprise_regex(info, find_integration_name())
     robot.logger.debug("HE registering call:\n"+

--- a/src/admin.coffee
+++ b/src/admin.coffee
@@ -90,12 +90,12 @@ module.exports = (robot) ->
 
   # register hubot enterprise functions
   robot.e.create {product: 'admin', verb: 'archive', entity: 'channel',
-  help: ' <this|#name>- archive specific channel', type: 'respond'},
+  help: '<this|#name>- archive specific channel', type: 'respond'},
   archive_channel
 
   robot.e.create {product: 'admin',
   verb: 'archive', entity: 'older',
   extra: '([0-9]+)([dDhHmMsS]) ?(.*)',
-  help: ' <N>(D/H/M/S) (named|tag) <name|tag> or <name|tag>- '+
+  help: '<N>(D/H/M/S) (named|tag) <name|tag> or <name|tag>- '+
   'archive channels older than by name or by topic', type: 'respond'},
   archive_older

--- a/test/enterprise-test.coffee
+++ b/test/enterprise-test.coffee
@@ -32,13 +32,13 @@ describe 'enterprise tests', ->
   beforeEach ->
     @room = helper.createRoom()
     @room.robot.e.create {product: 'test', verb: 'update', entity: 'ticket'
-    help: 'update ticket', type: 'respond'}, (msg, _robot)->
+    help: 'update ticket', type: 'respond'}, (msg)->
       msg.reply 'in test update ticket'
     @room.robot.e.create {product: 'test', verb: 'read', entity: 'issue'
-    help: 'read ticket', type: 'hear'}, (msg, _robot)->
+    help: 'read ticket', type: 'hear'}, (msg)->
       msg.reply 'in test read issue'
     @room.robot.e.create {product: 'foo', verb: 'read', entity: 'ticket'
-    help: 'read ticket', type: 'respond'}, (msg, _robot)->
+    help: 'read ticket', type: 'respond'}, (msg)->
       msg.reply 'in foo read ticket'
   afterEach ->
     @room.destroy()
@@ -58,7 +58,7 @@ describe 'enterprise tests', ->
 
   it 'register default project naming', ->
     @room.robot.e.create {verb: 'read',
-    help: 'read ticket', type: 'hear'}, (msg, _robot)->
+    help: 'read ticket', type: 'hear'}, (msg)->
       msg.reply 'in enterprise read'
     @room.user.say('alice', 'enterprise read jj').then =>
       expect(@room.messages).to.eql [
@@ -68,7 +68,7 @@ describe 'enterprise tests', ->
 
   it 'register default listener option (respond)', ->
     @room.robot.e.create {product: 'bar', verb: 'read',
-    help: 'read ticket'}, (msg, _robot)->
+    help: 'read ticket'}, (msg)->
       msg.reply 'in foo read'
     @room.user.say('alice', '@hubot bar read jj').then =>
       expect(@room.messages).to.eql [
@@ -102,10 +102,42 @@ describe 'enterprise tests', ->
         'there is no such integration bar' ]
       ]
 
+  it 'verb should exist', ->
+    err = 'none'
+    try
+      @room.robot.enterprise.create {product: 'foo2',
+      entity: 'ticket', help: 'read ticket', type: 'respond'}, (msg)->
+        msg.reply 'in foo2 read ticket'
+    catch error
+      err = error.message
+    expect(err).to.eql('Cannot register listener for foo2, no verb passed')
+
+  it 'verb should not contain spaces', ->
+    err = 'none'
+    try
+      @room.robot.enterprise.create {product: 'foo2', verb: 'with space'
+      entity: 'ticket', help: 'read ticket', type: 'respond'}, (msg)->
+        msg.reply 'in foo2 read ticket'
+    catch error
+      err = error.message
+    expect(err).to.eql('Cannot register listener for foo2, verb/entity must '+
+      'be a single word')
+
+  it 'entity should not contain spaces', ->
+    err = 'none'
+    try
+      @room.robot.enterprise.create {product: 'foo2', verb: 'with'
+      entity: 'with space', help: 'read ticket', type: 'respond'}, (msg)->
+        msg.reply 'in foo2 read ticket'
+    catch error
+      err = error.message
+    expect(err).to.eql('Cannot register listener for foo2, verb/entity must '+
+      'be a single word')
+      
   # test for backward compatibility robot.enterprise -> robot.e
   it 'check backward compatibility for robot.enterprise', ->
     @room.robot.enterprise.create {product: 'foo2', verb: 'read',
-    entity: 'ticket', help: 'read ticket', type: 'respond'}, (msg, _robot)->
+    entity: 'ticket', help: 'read ticket', type: 'respond'}, (msg)->
       msg.reply 'in foo2 read ticket'
     @room.user.say('alice', '@hubot foo2 read ticket').then =>
       expect(@room.messages).to.eql [
@@ -116,7 +148,7 @@ describe 'enterprise tests', ->
   # test backward compatibility for call set {product, action}
   it 'check backward compatibility for {product, action}', ->
     @room.robot.e.create {product: 'foo2', action: 'read',
-    help: 'read ticket', type: 'respond'}, (msg, _robot)->
+    help: 'read ticket', type: 'respond'}, (msg)->
       msg.reply 'in foo2 read'
     @room.user.say('alice', '@hubot foo2 read').then =>
       expect(@room.messages).to.eql [


### PR DESCRIPTION
Currently dealing only with whitespaces.
No special characters check and no '\t' check