### PR TITLE
Feature/he auth service integration

### DIFF
--- a/dc.auth.yml
+++ b/dc.auth.yml
@@ -22,26 +22,67 @@ services:
   he:
     environment:
       HE_ENABLE_AUTH: 1
-      HE_AUTH_SERVICE_ENDPOINT: https://auth
+      HE_AUTH_SERVICE_ENDPOINT: https://auth:3000
   auth:
-    image: chatopshpe/he-auth-service:latest
+#    image: chatopshpe/he-auth-service:latest
+    image: heauthservice_he-auth-service
     environment:
-      HE_AUTH_JWT_SECRET:
-      HE_ISSUER:
-      HE_AUDIENCE:
-      HE_AUTH_SSL_PASS:
-      VAULT_DEV_ROOT_TOKEN_ID:
-      HE_IDENTITY_PORTAL_ENDPOINT:
-      HE_IDENTITY_WS_ENDPOINT:
-    ports:
-      - "3000:3000"
+      HE_ISSUER: eedevops
+      HE_AUDIENCE: chatops_users
+      HE_AUTH_SSL_PASS: default
+      VAULT_DEV_ROOT_TOKEN_ID: myroot
+      HE_VAULT_HOST: vault
+      HE_VAULT_PORT: 8200
+      HE_IDENTITY_PORTAL_ENDPOINT: https://localhost:3002
+      HE_IDENTITY_WS_ENDPOINT: ws://identity-portal:3001
     depends_on:
       - vault
+      - identity-portal
     volumes:
       - ./certs:/usr/src/app/certs
+    networks:
+      - auth_net
+      - vault_net
   vault:
     image: vault:0.6.1
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: myroot
       # need to bind to 0.0.0.0 so that it accepts remote connections (!localhost)
       VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+    networks:
+      - vault_net
+  identity-portal:
+    image: heidentityportal_identity-portal:latest
+    networks:
+      - proxy_net
+      - idp_net
+      - auth_net
+    environment:
+      HE_REDIS_HOST: transient-datastore
+      HE_REDIS_PORT: 6379
+      HE_AUDIENCE: chatops_users
+      HE_ISSUER: eedevops
+    depends_on:
+      - transient-datastore
+  proxy:
+    image: nginx:1.11-alpine
+    volumes:
+      - $PWD/certs:/etc/nginx/external
+      - $PWD/script/nginx.conf:/etc/nginx/conf.d/docker-registry.conf
+    ports:
+      - "3002:443"
+    networks:
+      - proxy_net
+    depends_on:
+      - identity-portal
+  transient-datastore:
+    image: redis:3.2-alpine
+    networks:
+      - idp_net
+
+# TODO: limit visibility of docker containers if possible.
+networks:
+  proxy_net:
+  idp_net:
+  auth_net:
+  vault_net:

--- a/dc.auth.yml
+++ b/dc.auth.yml
@@ -26,8 +26,7 @@ services:
     networks:
       - auth_net
   auth:
-#    image: chatopshpe/he-auth-service:latest
-    image: heauthservice_he-auth-service
+    image: chatopshpe/he-auth-service:latest
     environment:
       HE_ISSUER: eedevops
       HE_AUDIENCE: chatops_users
@@ -54,7 +53,7 @@ services:
     networks:
       - vault_net
   identity-portal:
-    image: heidentityportal_identity-portal:latest
+    image: chatopshpe/he-identity-portal:latest
     networks:
       - proxy_net
       - idp_net

--- a/dc.auth.yml
+++ b/dc.auth.yml
@@ -26,11 +26,13 @@ services:
   auth:
     image: chatopshpe/he-auth-service:latest
     environment:
-      HE_IDENTITY_PORTAL_ENDPOINT: "https://example.com"
-      HE_AUTH_JWT_SECRET: secret
-      MONGO: "mongodb://mongo:27017"
-      HE_AUTH_SSL_PASS: default
-      VAULT_DEV_ROOT_TOKEN_ID: myroot
+      HE_AUTH_JWT_SECRET:
+      HE_ISSUER:
+      HE_AUDIENCE:
+      HE_AUTH_SSL_PASS:
+      VAULT_DEV_ROOT_TOKEN_ID:
+      HE_IDENTITY_PORTAL_ENDPOINT:
+      HE_IDENTITY_WS_ENDPOINT:
     ports:
       - "3000:3000"
     depends_on:

--- a/dc.auth.yml
+++ b/dc.auth.yml
@@ -23,6 +23,8 @@ services:
     environment:
       HE_ENABLE_AUTH: 1
       HE_AUTH_SERVICE_ENDPOINT: https://auth:3000
+    networks:
+      - auth_net
   auth:
 #    image: chatopshpe/he-auth-service:latest
     image: heauthservice_he-auth-service
@@ -33,7 +35,7 @@ services:
       VAULT_DEV_ROOT_TOKEN_ID: myroot
       HE_VAULT_HOST: vault
       HE_VAULT_PORT: 8200
-      HE_IDENTITY_PORTAL_ENDPOINT: https://localhost:3002
+      HE_IDENTITY_PORTAL_ENDPOINT: https://localhost:443
       HE_IDENTITY_WS_ENDPOINT: ws://identity-portal:3001
     depends_on:
       - vault
@@ -64,13 +66,15 @@ services:
       HE_ISSUER: eedevops
     depends_on:
       - transient-datastore
+    volumes:
+      - ./certs:/server/certs
   proxy:
     image: nginx:1.11-alpine
     volumes:
       - $PWD/certs:/etc/nginx/external
       - $PWD/script/nginx.conf:/etc/nginx/conf.d/docker-registry.conf
     ports:
-      - "3002:443"
+      - "443:443"
     networks:
       - proxy_net
     depends_on:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-enterprise",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Hubot middleware and scripts for enterprise",
   "main": "index.coffee",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "moment": "^2.13.0",
     "nock": "^8.1.0",
     "node-jose": "^0.9.1",
+    "node-uuid": "^1.4.7",
     "request": "^2.69.0"
   },
   "peerDependencies": {

--- a/script/nginx.conf
+++ b/script/nginx.conf
@@ -1,0 +1,33 @@
+# For versions of Nginx > 1.3.9 that include chunked transfer encoding support
+# Replace with appropriate values where necessary
+
+upstream identity-portal {
+ server identity-portal:3002;
+}
+
+server {
+ listen 443 default_server;
+ ssl on;
+ ssl_certificate /etc/nginx/external/cert.pem;
+ ssl_certificate_key /etc/nginx/external/key.pem;
+
+ # set HSTS-Header because we only allow https traffic
+ add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+
+ proxy_set_header Host       $http_host;   # required so that images and other webpage assets are loaded correctly
+ #proxy_set_header X-Real-IP  $remote_addr; # pass on real client IP
+
+ client_max_body_size 0; # disable any limits to avoid HTTP 413 for large image uploads
+
+ # required to avoid HTTP 411: see Issue #1486 (https://github.com/dotcloud/docker/issues/1486)
+ chunked_transfer_encoding on;
+
+ location / {
+     # let Nginx know about our auth file
+     auth_basic off;
+     proxy_set_header  Host              $http_host;   # required for docker client's sake
+     proxy_set_header  X-Forwarded-Proto $scheme; # required so that images and other webpage assets are loaded correctly
+     proxy_read_timeout                  900;
+     proxy_pass http://identity-portal;
+ }
+}


### PR DESCRIPTION
@mosheBelostotsky once this PR https://github.com/eedevops/he-identity-portal/pull/36 is reviewed and merged by @JonathanRosado, we should have ready the docker images for the `he-auth-service` and the `he-identity-portal` that work well with this PR to `hubot-enterprise`. When this is done, you should replace the `image: <image-name>` to this PR of each of those services to point to the ones in the docker hub. So, instead of:

```
image: heauthservice_he-auth-service
```
replace it with 

```
image: chatopshpe/he-auth-service:latest
```

Thanks!