### PR TITLE
Fix issue with robot.warning not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-enterprise",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Hubot middleware and scripts for enterprise",
   "main": "index.coffee",
   "repository": {

--- a/src/0_bootstrap.coffee
+++ b/src/0_bootstrap.coffee
@@ -69,7 +69,7 @@ module.exports = (robot) ->
   consoleOpts = {
     colorize: true,
     timestamp: true,
-    level: process.env.LOG_LEVEL || 'debug'  
+    level: process.env.LOG_LEVEL || 'debug'
   }
 
   transports = [new(winstonLogger.transports.Console)(consoleOpts)]
@@ -89,7 +89,9 @@ module.exports = (robot) ->
   winstonLogger.configure({
     transports: transports,
     exitOnError: false
-  })  
+  })
+  winstonLogger.setLevels(winstonLogger.config.syslog.levels)
+
   robot.logger = winstonLogger
   # load scripts to robot
   load_he_scripts = (path) ->


### PR DESCRIPTION
Change `winston` default to syslog level to fix issue with `robot.warning / robot.warn` API discrepancy.