### PR TITLE
generator-hubot-enterprise is broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV ADAPTER slack
 RUN mkdir /bot && \
     useradd -ms /bin/bash node && \
     chown -R node /bot && \
-    npm install -g yo@1.7.0 coffee-script eedevops/generator-hubot-enterprise
+    npm install -g yo@1.7.0 coffee-script eedevops/generator-hubot-enterprise#2c2234052148d6d620b80a281a40b804da09fffc
 
 WORKDIR /bot
 ADD . /he

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-enterprise",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Hubot middleware and scripts for enterprise",
   "main": "index.coffee",
   "repository": {


### PR DESCRIPTION
After a contributed PR in generator-hubot-enterprise, it broke the docker build. This error was happening in runtime:

```
error: Error loading scripts from npm package - AssertionError: missing path
he_1                   |   at Module.require (module.js:481:3)
he_1                   |   at require (internal/module.js:20:19)
he_1                   |   at Robot.loadExternalScripts (/bot/node_modules/hubot/src/robot.coffee:401:11, <js>:272:27)
he_1                   |   at /bot/node_modules/hubot/bin/hubot:152:11, <js>:159:26
he_1                   |   at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:445:3)
```

Hardcoding to last working version of generator.